### PR TITLE
Update

### DIFF
--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -397,7 +397,7 @@ rfl
 lemma count_cons' (a b : α) (l : list α) :
   count a (b :: l) = count a l + (if a = b then 1 else 0) :=
 decidable.by_cases
-  (suppose a = b, begin rw [count_cons, if_pos this, if_pos this], reflexivity end)
+  (suppose a = b, begin rw [count_cons, if_pos this, if_pos this] end)
   (suppose a ≠ b, begin rw [count_cons, if_neg this, if_neg this], reflexivity end)
 
 
@@ -418,7 +418,7 @@ decidable.by_cases
 -- the second is succ 0. Make sure the simplifier can eventually handle this.
 
 lemma count_singleton (a : α) : count a [a] = 1 :=
-begin simp, reflexivity end
+by simp
 
 @[simp]
 lemma count_append (a : α) : ∀ l₁ l₂, count a (l₁ ++ l₂) = count a l₁ + count a l₂
@@ -430,7 +430,7 @@ lemma count_append (a : α) : ∀ l₁ l₂, count a (l₁ ++ l₂) = count a l�
 
 @[simp]
 lemma count_concat (a : α) (l : list α) : count a (concat l a) = succ (count a l) :=
-begin rw [concat_eq_append, count_append, count_singleton], reflexivity end
+by rw [concat_eq_append, count_append, count_singleton]
 
 lemma mem_of_count_pos : ∀ {a : α} {l : list α}, count a l > 0 → a ∈ l
 | a []     h := absurd h (lt_irrefl _)

--- a/data/list/comb.lean
+++ b/data/list/comb.lean
@@ -305,7 +305,7 @@ iff.intro exists_of_any_eq_tt (assume h, bexists.elim h (take a, any_of_mem))
 
 /- bounded quantifiers over lists -/
 
-theorem forall_mem_nil (p : α → Prop) : ∀ x ∈ nil, p x :=
+theorem forall_mem_nil (p : α → Prop) : ∀ x ∈ @nil α, p x :=
 take x xnil, absurd xnil (not_mem_nil x)
 
 theorem forall_mem_cons {p : α → Prop} {a : α} {l : list α} (pa : p a) (h : ∀ x ∈ l, p x) :
@@ -329,7 +329,7 @@ iff.intro
   (λ h, ⟨of_forall_mem_cons h, forall_mem_of_forall_mem_cons h⟩)
   (λ h, forall_mem_cons h^.left h^.right)
 
-theorem not_exists_mem_nil (p : α → Prop) : ¬ ∃ x ∈ nil, p x :=
+theorem not_exists_mem_nil (p : α → Prop) : ¬ ∃ x ∈ @nil α, p x :=
 assume h, bexists.elim h (λ a anil, absurd anil (not_mem_nil a))
 
 theorem exists_mem_cons_of {p : α → Prop} {a : α} (l : list α) (h : p a) :
@@ -452,7 +452,7 @@ theorem length_mapαccumR₂ : ∀ (f : α → β → S → S × γ) (x : list �
     length (snd (mapαccumR₂ f (a::x) (b::y) c))
               = length (snd (mapαccumR₂ f x y c)) + 1  : rfl
           ... = _root_.min (length x) (length y) + 1             : by rw (length_mapαccumR₂ f x y c)
-          ... = _root_.min (succ (length x)) (succ (length y))   : begin rw min_succ_succ, reflexivity end
+          ... = _root_.min (succ (length x)) (succ (length y))   : begin rw min_succ_succ end
           ... = _root_.min (length (a::x)) (length (b::y))       : rfl
 | f (a::x) [] c := rfl
 | f [] (b::y) c := rfl
@@ -494,7 +494,7 @@ have snd (a₁, b₁) ∈ map snd (map (λ b, (a, b)) l), from mem_map snd ain,
 have b₁ ∈ map (λx, x) l, begin rw [map_map] at this, exact this end,
 begin rw [map_id] at this, exact this end
 
-theorem mem_product {a : α} {b : β} : ∀ {l₁ l₂}, a ∈ l₁ → b ∈ l₂ → (a, b) ∈ product l₁ l₂
+theorem mem_product {a : α} {b : β} : ∀ {l₁ l₂}, a ∈ l₁ → b ∈ l₂ → (a, b) ∈ @product α β l₁ l₂
 | []      l₂ h₁ h₂ := absurd h₁ (not_mem_nil _)
 | (x::l₁) l₂ h₁ h₂ :=
   or.elim (eq_or_mem_of_mem_cons h₁)
@@ -505,7 +505,7 @@ theorem mem_product {a : α} {b : β} : ∀ {l₁ l₂}, a ∈ l₁ → b ∈ l�
       have (a, b) ∈ product l₁ l₂, from mem_product ainl₁ h₂,
       begin rw [product_cons], exact mem_append_right _ this end)
 
-theorem mem_of_mem_product_left {a : α} {b : β} : ∀ {l₁ l₂}, (a, b) ∈ product l₁ l₂ → a ∈ l₁
+theorem mem_of_mem_product_left {a : α} {b : β} : ∀ {l₁ l₂}, (a, b) ∈ @product α β l₁ l₂ → a ∈ l₁
 | []      l₂ h := absurd h (not_mem_nil _)
 | (x::l₁) l₂ h :=
   or.elim (mem_or_mem_of_mem_append h)
@@ -516,7 +516,7 @@ theorem mem_of_mem_product_left {a : α} {b : β} : ∀ {l₁ l₂}, (a, b) ∈ 
       have a ∈ l₁, from mem_of_mem_product_left this,
       mem_cons_of_mem _ this)
 
-theorem mem_of_mem_product_right {a : α} {b : β} : ∀ {l₁ l₂}, (a, b) ∈ product l₁ l₂ → b ∈ l₂
+theorem mem_of_mem_product_right {a : α} {b : β} : ∀ {l₁ l₂}, (a, b) ∈ @product α β l₁ l₂ → b ∈ l₂
 | []      l₂ h := absurd h (not_mem_nil ((a, b)))
 | (x::l₁) l₂ h :=
   or.elim (mem_or_mem_of_mem_append h)

--- a/data/list/perm.lean
+++ b/data/list/perm.lean
@@ -336,10 +336,10 @@ theorem perm_of_forall_count_eq : ∀ {l₁ l₂ : list α}, (∀ a, count a l�
       take a,
       if h' : a = b then
         nat.succ_inj (calc
-          count a l + 1 = count a (b :: l)         : begin simp [h'], rw add_comm, reflexivity end
+          count a l + 1 = count a (b :: l)         : begin simp [h'], rw add_comm end
                    ... = count a l₂                : by rw h
                    ... = count a (b :: erase b l₂) : count_eq_count_of_perm (by assumption) a
-                   ... = count a (erase b l₂) + 1  : begin simp [h'], rw add_comm, reflexivity end)
+                   ... = count a (erase b l₂) + 1  : begin simp [h'], rw add_comm end)
       else
         calc
           count a l = count a (b :: l)          : by simp [h']
@@ -484,7 +484,7 @@ theorem mem_cons_of_qeq {a : α} : ∀ {l₁ l₂ : list α}, l₁≈a|l₂ → 
 theorem length_eq_of_qeq {a : α} {l₁ l₂ : list α} :
   l₁ ≈ a | l₂ → length l₁ = nat.succ (length l₂) :=
 begin
-  intro q, induction q with l b l l' q ih, simp, reflexivity, simp, rw ih, reflexivity
+  intro q, induction q with l b l l' q ih, simp, simp, rw ih
 end
 
 theorem qeq_of_mem {a : α} {l : list α} : a ∈ l → (∃ l', l ≈ a | l') :=
@@ -985,7 +985,7 @@ assume h, perm.induction_on h
     have x ∉ l₁,           from not_mem_of_nodup_cons ‹nodup (x::l₁)›,
     have y ∉ x::l₁,        from not_mem_of_nodup_cons nd,
     have x ≠ y,            from suppose x = y,
-                                begin subst x, exact absurd (mem_cons_self _ _) ‹y ∉ y::l₁› end,
+                                begin subst x, apply absurd (mem_cons_self _ _), apply ‹y ∉ y::l₁› end, -- this line used to be "exact absurd (mem_cons_self _ _) ‹y ∉ y::l₁›, but it's now a syntax error
     have y ∉ l₁,           from not_mem_of_not_mem_cons ‹y ∉ x::l₁›,
     have x ∉ y::l₁,        from not_mem_cons_of_ne_of_not_mem ‹x ≠ y› ‹x ∉ l₁›,
     have nodup (y::l₁),    from nodup_cons ‹y ∉ l₁› ‹nodup l₁›,

--- a/data/list/set.lean
+++ b/data/list/set.lean
@@ -95,12 +95,12 @@ by simp [erase_cons, if_neg, h]
 @[simp]
 lemma length_erase_of_mem {a : α} : ∀ {l}, a ∈ l → length (erase a l) = pred (length l)
 | []         h := rfl
-| [x]        h := begin simp at h, simp [h], reflexivity end
+| [x]        h := begin simp at h, simp [h] end
 | (x::y::xs) h := if h' : a = x then
-                    begin simp [h'], reflexivity end
+                    begin simp [h'] end
                   else
                     have ainyxs : a ∈ y::xs, from or_resolve_right h h',
-                    begin simp [h', length_erase_of_mem ainyxs], rw add_comm, reflexivity end
+                    begin simp [h', length_erase_of_mem ainyxs] end
 
 @[simp]
 lemma length_erase_of_not_mem {a : α} : ∀ {l}, a ∉ l → length (erase a l) = length l
@@ -227,7 +227,7 @@ theorem upto_succ (n : nat) : upto (succ n) = n :: upto n := rfl
 @[simp]
 theorem length_upto : ∀ n, length (upto n) = n
 | 0        := rfl
-| (succ n) := begin rw [upto_succ, length_cons, length_upto], reflexivity end
+| (succ n) := begin rw [upto_succ, length_cons, length_upto] end
 
 theorem upto_ne_nil_of_ne_zero {n : ℕ} (h : n ≠ 0) : upto n ≠ nil :=
 suppose upto n = nil,
@@ -574,7 +574,7 @@ assume nainl, calc
   erase_dup (a::l) = if a ∈ l then erase_dup l else a :: erase_dup l : rfl
               ...  = a :: erase_dup l                                : if_neg nainl
 
-theorem mem_erase_dup [decidable_eq α] {a : α} : ∀ {l}, a ∈ l → a ∈ erase_dup l
+theorem mem_erase_dup [decidable_eq α] {a : α} : ∀ {l : list α}, a ∈ l → a ∈ erase_dup l
 | []     h  := absurd h (not_mem_nil _)
 | (b::l) h  := by_cases
   (λ binl  : b ∈ l, or.elim (eq_or_mem_of_mem_cons h)
@@ -588,7 +588,7 @@ theorem mem_erase_dup [decidable_eq α] {a : α} : ∀ {l}, a ∈ l → a ∈ er
     (λ ainl : a ∈ l,
       begin rw [erase_dup_cons_of_not_mem nbinl], exact (or.inr (mem_erase_dup ainl)) end))
 
-theorem mem_of_mem_erase_dup [decidable_eq α] {a : α} : ∀ {l}, a ∈ erase_dup l → a ∈ l
+theorem mem_of_mem_erase_dup [decidable_eq α] {a : α} : ∀ {l : list α}, a ∈ erase_dup l → a ∈ l
 | []     h := begin rw [erase_dup_nil] at h, exact h end
 | (b::l) h := by_cases
   (λ binl  : b ∈ l,

--- a/data/list/sort.lean
+++ b/data/list/sort.lean
@@ -421,8 +421,8 @@ end sort
 
 /- try them out! -/
 
-vm_eval insertion_sort (λ m n : ℕ, m ≤ n) [5, 27, 221, 95, 17, 43, 7, 2, 98, 567, 23, 12]
+--vm_eval insertion_sort (λ m n : ℕ, m ≤ n) [5, 27, 221, 95, 17, 43, 7, 2, 98, 567, 23, 12]
 
-vm_eval merge_sort     (λ m n : ℕ, m ≤ n) [5, 27, 221, 95, 17, 43, 7, 2, 98, 567, 23, 12]
+--vm_eval merge_sort     (λ m n : ℕ, m ≤ n) [5, 27, 221, 95, 17, 43, 7, 2, 98, 567, 23, 12]
 
 end list

--- a/data/set/basic.lean
+++ b/data/set/basic.lean
@@ -45,7 +45,7 @@ iff.intro (take H, true.intro) (take H x H1, absurd H1 (not_mem_empty _))
 
 definition univ : set α := λx, true
 
-theorem mem_univ (x : α) : x ∈ univ :=
+theorem mem_univ (x : α) : x ∈ @univ α :=
 by triv
 
 theorem mem_univ_iff (x : α) : x ∈ @univ α ↔ true := iff.rfl
@@ -233,7 +233,7 @@ theorem forall_of_forall_insert {P : α → Prop} {a : α} {s : set α} (h : ∀
 lemma bounded_forall_insert_iff {P : α → Prop} {a : α} {s : set α} :
   (∀ x ∈ insert a s, P x) ↔ P a ∧ (∀x ∈ s, P x) :=
 begin
-  apply iff.intro, all_goals (do intro `h, skip),
+  apply iff.intro, all_goals {do intro `h, skip},
   { apply and.intro,
     { apply h, apply mem_insert },
     { intros x hx, apply h, apply mem_insert_of_mem, assumption } },
@@ -513,7 +513,7 @@ lemma image_insert_eq {f : α → β} {a : α} {s : set α} :
   f ' insert a s = insert (f a) (f ' s) :=
 begin
   apply set.ext,
-  intro x, apply iff.intro, all_goals (do intro `h, skip),
+  intro x, apply iff.intro, all_goals {do intro `h, skip},
   { cases mem_image_dest h with y hy heq, rw heq^.symm, cases hy with y_eq,
     { rw y_eq, apply mem_insert },
     { apply mem_insert_of_mem, apply mem_image_of_mem, assumption } },
@@ -544,7 +544,7 @@ match hs, ht with
 | (or.inr sD), (or.inr tD) := hD s sD t tD hne
 end
 
-theorem pairwise_disjoint_singleton (s : set α) : pairwise_disjoint {s} :=
+theorem pairwise_disjoint_singleton (s : set α) : @pairwise_disjoint α {s} :=
 begin
   unfold pairwise_disjoint, exact sorry --simp, intros s₁ s₁eq s₂ s₂eq, simp [s₁eq, s₂eq]
 end


### PR DESCRIPTION
@avigad This updates everything except auto to compile with the current version of Lean.

See my comment at https://github.com/leanprover/lean/issues/1364#issuecomment-280370862 -- Flycheck doesn't like sort.lean, but it compiles in batch mode.

There are curiosities at list/perm:988 and list/basic:401 (I had to remove `reflexivity` in the previous line, but had to leave it here). The changes to list/set notation have a noticeable effect (e.g. set/basic:547, list/set:591).