### PR TITLE
Change uses of "assume :" to "suppose"

### DIFF
--- a/algebra/group_power.lean
+++ b/algebra/group_power.lean
@@ -125,13 +125,13 @@ open nat
 private lemma gpow_add_aux (a : α) (m n : nat) :
   gpow a ((of_nat m) + -[1+n]) = gpow a (of_nat m) * gpow a (-[1+n]) :=
 or.elim (nat.lt_or_ge m (nat.succ n))
- (assume : m < succ n,
+ (suppose m < succ n,
   have m ≤ n, from le_of_lt_succ this,
   suffices gpow a -[1+ n-m] = (gpow a (of_nat m)) * (gpow a -[1+n]), by simp [*, of_nat_add_neg_succ_of_nat_of_lt],
   suffices (a^(nat.succ (n - m)))⁻¹ = (gpow a (of_nat m)) * (gpow a -[1+n]), from this,
   suffices (a^(nat.succ n - m))⁻¹ = (gpow a (of_nat m)) * (gpow a -[1+n]), by rw ←succ_sub; assumption,
   by rw pow_sub; finish [gpow])
- (assume : m ≥ succ n,
+ (suppose m ≥ succ n,
   suffices gpow a (of_nat (m - succ n)) = (gpow a (of_nat m)) * (gpow a -[1+ n]), 
     by rw [of_nat_add_neg_succ_of_nat_of_ge]; assumption,
   suffices a ^ (m - succ n) = a^m * (a^succ n)⁻¹, from this,

--- a/algebra/lattice/complete_lattice.lean
+++ b/algebra/lattice/complete_lattice.lean
@@ -61,12 +61,12 @@ lemma Inf_le_Inf (h : s ⊆ t) : Inf t ≤ Inf s :=
 le_Inf (assume a, assume ha : a ∈ s, Inf_le $ h ha)
 
 lemma le_Sup_iff : Sup s ≤ a ↔ (∀b ∈ s, b ≤ a) :=
-⟨assume : Sup s ≤ a, assume b, assume : b ∈ s,
+⟨suppose Sup s ≤ a, assume b, suppose b ∈ s,
   le_trans (le_Sup ‹b ∈ s›) ‹Sup s ≤ a›,
   Sup_le⟩
 
 lemma Inf_le_iff : a ≤ Inf s ↔ (∀b ∈ s, a ≤ b) :=
-⟨assume : a ≤ Inf s, assume b, assume : b ∈ s,
+⟨suppose a ≤ Inf s, assume b, suppose b ∈ s,
   le_trans ‹a ≤ Inf s› (Inf_le ‹b ∈ s›),
   le_Inf⟩
 
@@ -156,7 +156,7 @@ lemma supr_le_supr_const (h : ι → ι₂) : (⨆ i:ι, a) ≤ (⨆ j:ι₂, a)
 supr_le $ le_supr _ ∘ h
 
 lemma supr_le_iff : supr s ≤ a ↔ (∀i, s i ≤ a) :=
-⟨assume : supr s ≤ a, assume i, le_trans (le_supr _ _) this, supr_le⟩
+⟨suppose supr s ≤ a, assume i, le_trans (le_supr _ _) this, supr_le⟩
 
 @[congr]
 lemma supr_congr_Prop {p q : Prop} {f₁ : p → α} {f₂ : q → α}
@@ -184,7 +184,7 @@ lemma infi_le_infi_const (h : ι₂ → ι) : (⨅ i:ι, a) ≤ (⨅ j:ι₂, a)
 le_infi $ infi_le _ ∘ h
 
 lemma le_infi_iff : a ≤ infi s ↔ (∀i, a ≤ s i) :=
-⟨assume : a ≤ infi s, assume i, le_trans this (infi_le _ _), le_infi⟩
+⟨suppose a ≤ infi s, assume i, le_trans this (infi_le _ _), le_infi⟩
 
 @[congr]
 lemma infi_congr_Prop {p q : Prop} {f₁ : p → α} {f₂ : q → α}
@@ -272,14 +272,14 @@ le_antisymm (supr_le $ assume ⟨⟩, le_refl _) (le_supr _ _)
 @[simp]
 lemma infi_exists {p : ι → Prop} {f : Exists p → α} : (⨅ x, f x) = (⨅ i, ⨅ h:p i, f ⟨i, h⟩) :=
 le_antisymm
-  (le_infi $ assume i, le_infi $ assume : p i, infi_le _ _)
+  (le_infi $ assume i, le_infi $ suppose p i, infi_le _ _)
   (le_infi $ assume ⟨i, h⟩, infi_le_of_le i $ infi_le _ _)
 
 @[simp]
 lemma supr_exists {p : ι → Prop} {f : Exists p → α} : (⨆ x, f x) = (⨆ i, ⨆ h:p i, f ⟨i, h⟩) :=
 le_antisymm
   (supr_le $ assume ⟨i, h⟩, le_supr_of_le i $ le_supr (λh:p i, f ⟨i, h⟩) _)
-  (supr_le $ assume i, supr_le $ assume : p i, le_supr _ _)
+  (supr_le $ assume i, supr_le $ suppose p i, le_supr _ _)
 
 lemma infi_and {p q : Prop} {s : p ∧ q → α} : infi s = (⨅ h₁ : p, ⨅ h₂ : q, s ⟨h₁, h₂⟩) :=
 le_antisymm
@@ -408,23 +408,23 @@ le_antisymm (supr_le $ assume ⟨⟩, le_refl _) (le_supr _ _)
 
 lemma infi_subtype {p : ι → Prop} {f : subtype p → α} : (⨅ x, f x) = (⨅ i, ⨅ h:p i, f ⟨i, h⟩) :=
 le_antisymm
-  (le_infi $ assume i, le_infi $ assume : p i, infi_le _ _)
+  (le_infi $ assume i, le_infi $ suppose p i, infi_le _ _)
   (le_infi $ assume ⟨i, h⟩, infi_le_of_le i $ infi_le _ _)
 
 lemma supr_subtype {p : ι → Prop} {f : subtype p → α} : (⨆ x, f x) = (⨆ i, ⨆ h:p i, f ⟨i, h⟩) :=
 le_antisymm
   (supr_le $ assume ⟨i, h⟩, le_supr_of_le i $ le_supr (λh:p i, f ⟨i, h⟩) _)
-  (supr_le $ assume i, supr_le $ assume : p i, le_supr _ _)
+  (supr_le $ assume i, supr_le $ suppose p i, le_supr _ _)
 
 lemma infi_sigma {p : β → Type w} {f : sigma p → α} : (⨅ x, f x) = (⨅ i, ⨅ h:p i, f ⟨i, h⟩) :=
 le_antisymm
-  (le_infi $ assume i, le_infi $ assume : p i, infi_le _ _)
+  (le_infi $ assume i, le_infi $ suppose p i, infi_le _ _)
   (le_infi $ assume ⟨i, h⟩, infi_le_of_le i $ infi_le _ _)
 
 lemma supr_sigma {p : β → Type w} {f : sigma p → α} : (⨆ x, f x) = (⨆ i, ⨆ h:p i, f ⟨i, h⟩) :=
 le_antisymm
   (supr_le $ assume ⟨i, h⟩, le_supr_of_le i $ le_supr (λh:p i, f ⟨i, h⟩) _)
-  (supr_le $ assume i, supr_le $ assume : p i, le_supr _ _)
+  (supr_le $ assume i, supr_le $ suppose p i, le_supr _ _)
 
 lemma infi_prod {γ : Type w} {f : β × γ → α} : (⨅ x, f x) = (⨅ i, ⨅ j, f (i, j)) :=
 le_antisymm

--- a/algebra/lattice/complete_lattice_experiment.lean
+++ b/algebra/lattice/complete_lattice_experiment.lean
@@ -101,13 +101,13 @@ le_Inf (assume a, assume ha : a ∈ s, Inf_le $ h ha)
 
 @[simp]
 lemma le_Sup_iff : Sup s ≤ a ↔ (∀b ∈ s, b ≤ a) :=
-⟨assume : Sup s ≤ a, assume b, assume : b ∈ s,
+⟨suppose Sup s ≤ a, assume b, suppose b ∈ s,
   le_trans (le_Sup ‹b ∈ s›) ‹Sup s ≤ a›,
   Sup_le⟩
 
 @[simp]
 lemma Inf_le_iff : a ≤ Inf s ↔ (∀b ∈ s, a ≤ b) :=
-⟨assume : a ≤ Inf s, assume b, assume : b ∈ s,
+⟨suppose a ≤ Inf s, assume b, suppose b ∈ s,
   le_trans ‹a ≤ Inf s› (Inf_le ‹b ∈ s›),
   le_Inf⟩
 
@@ -240,7 +240,7 @@ supr_le $ le_supr _ ∘ h
 
 @[simp]
 lemma supr_le_iff : supr s ≤ a ↔ (∀i, s i ≤ a) :=
-⟨assume : supr s ≤ a, assume i, le_trans (le_supr _ _) this, supr_le⟩
+⟨suppose supr s ≤ a, assume i, le_trans (le_supr _ _) this, supr_le⟩
 
 -- TODO: finish doesn't do well here.
 @[congr]
@@ -289,7 +289,7 @@ le_infi $ infi_le _ ∘ h
 
 @[simp]
 lemma le_infi_iff : a ≤ infi s ↔ (∀i, a ≤ s i) :=
-⟨assume : a ≤ infi s, assume i, le_trans this (infi_le _ _), le_infi⟩
+⟨suppose a ≤ infi s, assume i, le_trans this (infi_le _ _), le_infi⟩
 
 @[congr]
 lemma infi_congr_Prop {p q : Prop} {f₁ : p → α} {f₂ : q → α}
@@ -414,14 +414,14 @@ le_antisymm (supr_le $ assume ⟨⟩, le_refl _) (le_supr _ _)
 @[simp]
 lemma infi_exists {p : ι → Prop} {f : Exists p → α} : (⨅ x, f x) = (⨅ i, ⨅ h:p i, f ⟨i, h⟩) :=
 le_antisymm
-  (le_infi $ assume i, le_infi $ assume : p i, infi_le _ _)
+  (le_infi $ assume i, le_infi $ suppose p i, infi_le _ _)
   (le_infi $ assume ⟨i, h⟩, infi_le_of_le i $ infi_le _ _)
 
 @[simp]
 lemma supr_exists {p : ι → Prop} {f : Exists p → α} : (⨆ x, f x) = (⨆ i, ⨆ h:p i, f ⟨i, h⟩) :=
 le_antisymm
   (supr_le $ assume ⟨i, h⟩, le_supr_of_le i $ le_supr (λh:p i, f ⟨i, h⟩) _)
-  (supr_le $ assume i, supr_le $ assume : p i, le_supr _ _)
+  (supr_le $ assume i, supr_le $ suppose p i, le_supr _ _)
 
 lemma infi_and {p q : Prop} {s : p ∧ q → α} : infi s = (⨅ h₁ : p, ⨅ h₂ : q, s ⟨h₁, h₂⟩) :=
 le_antisymm
@@ -550,23 +550,23 @@ le_antisymm (supr_le $ assume ⟨⟩, le_refl _) (le_supr _ _)
 
 lemma infi_subtype {p : ι → Prop} {f : subtype p → α} : (⨅ x, f x) = (⨅ i, ⨅ h:p i, f ⟨i, h⟩) :=
 le_antisymm
-  (le_infi $ assume i, le_infi $ assume : p i, infi_le _ _)
+  (le_infi $ assume i, le_infi $ suppose p i, infi_le _ _)
   (le_infi $ assume ⟨i, h⟩, infi_le_of_le i $ infi_le _ _)
 
 lemma supr_subtype {p : ι → Prop} {f : subtype p → α} : (⨆ x, f x) = (⨆ i, ⨆ h:p i, f ⟨i, h⟩) :=
 le_antisymm
   (supr_le $ assume ⟨i, h⟩, le_supr_of_le i $ le_supr (λh:p i, f ⟨i, h⟩) _)
-  (supr_le $ assume i, supr_le $ assume : p i, le_supr _ _)
+  (supr_le $ assume i, supr_le $ suppose p i, le_supr _ _)
 
 lemma infi_sigma {p : β → Type w} {f : sigma p → α} : (⨅ x, f x) = (⨅ i, ⨅ h:p i, f ⟨i, h⟩) :=
 le_antisymm
-  (le_infi $ assume i, le_infi $ assume : p i, infi_le _ _)
+  (le_infi $ assume i, le_infi $ suppose p i, infi_le _ _)
   (le_infi $ assume ⟨i, h⟩, infi_le_of_le i $ infi_le _ _)
 
 lemma supr_sigma {p : β → Type w} {f : sigma p → α} : (⨆ x, f x) = (⨆ i, ⨆ h:p i, f ⟨i, h⟩) :=
 le_antisymm
   (supr_le $ assume ⟨i, h⟩, le_supr_of_le i $ le_supr (λh:p i, f ⟨i, h⟩) _)
-  (supr_le $ assume i, supr_le $ assume : p i, le_supr _ _)
+  (supr_le $ assume i, supr_le $ suppose p i, le_supr _ _)
 
 lemma infi_prod {γ : Type w} {f : β × γ → α} : (⨅ x, f x) = (⨅ i, ⨅ j, f (i, j)) :=
 le_antisymm

--- a/algebra/lattice/filter.lean
+++ b/algebra/lattice/filter.lean
@@ -232,7 +232,7 @@ lemma Union_subset_Union_const {ι₂ : Sort x} {s : set α} (h : ι → ι₂) 
 @supr_le_supr_const (set α) ι ι₂ _ s h
 
 lemma diff_neq_empty {s t : set α} : s - t = ∅ ↔ s ⊆ t :=
-⟨assume h x hx, classical.by_contradiction $ assume : x ∉ t, show x ∈ (∅ : set α), from h ▸ ⟨hx, this⟩,
+⟨assume h x hx, classical.by_contradiction $ suppose x ∉ t, show x ∈ (∅ : set α), from h ▸ ⟨hx, this⟩,
   assume h, bot_unique $ assume x ⟨hx, hnx⟩, hnx $ h hx⟩
 
 @[simp]
@@ -270,11 +270,11 @@ le_antisymm
 
 lemma inf_eq_bot_iff_le_compl {α : Type u} [bounded_distrib_lattice α] {a b c : α}
   (h₁ : b ⊔ c = ⊤) (h₂ : b ⊓ c = ⊥) : a ⊓ b = ⊥ ↔ a ≤ c :=
-⟨assume : a ⊓ b = ⊥,
+⟨suppose a ⊓ b = ⊥,
   calc a ≤ a ⊓ (b ⊔ c) : by simp [h₁]
     ... = (a ⊓ b) ⊔ (a ⊓ c) : by simp [inf_sup_left]
     ... ≤ c : by simp [this, inf_le_right],
-  assume : a ≤ c,
+  suppose a ≤ c,
   bot_unique $
     calc a ⊓ b ≤ b ⊓ c : by rw [inf_comm]; exact inf_le_inf (le_refl _) this
       ... = ⊥ : h₂⟩
@@ -320,12 +320,12 @@ lemma directed_of_chain {α : Type u} {β : Type v} [weak_order β] {f : α → 
   (h : @zorn.chain α (λa b, f b ≤ f a) c) :
   directed (≤) (λx:{a:α // a ∈ c}, f (x.val)) :=
 assume ⟨a, ha⟩ ⟨b, hb⟩, classical.by_cases
-  (assume : a = b, begin simp [this]; exact ⟨⟨b, hb⟩, le_refl _⟩ end)
-  (assume : a ≠ b,
+  (suppose a = b, begin simp [this]; exact ⟨⟨b, hb⟩, le_refl _⟩ end)
+  (suppose a ≠ b,
     have f b ≤ f a ∨ f a ≤ f b, from h a ha b hb this,
     or.elim this
-      (assume : f b ≤ f a, ⟨⟨b, hb⟩, this, le_refl _⟩)
-      (assume : f a ≤ f b, ⟨⟨a, ha⟩, le_refl _, this⟩))
+      (suppose f b ≤ f a, ⟨⟨b, hb⟩, this, le_refl _⟩)
+      (suppose f a ≤ f b, ⟨⟨a, ha⟩, le_refl _, this⟩))
 
 structure filter (α : Type u) :=
 (sets           : set (set α))
@@ -553,7 +553,7 @@ assume x, false.elim
 
 lemma empty_in_sets_eq_bot {f : filter α} : ∅ ∈ f^.sets ↔ f = ⊥ :=
 ⟨assume h, bot_unique $ assume s _, f.upwards_sets h (empty_subset s),
-  assume : f = ⊥, this.symm ▸ mem_bot_sets⟩
+  suppose f = ⊥, this.symm ▸ mem_bot_sets⟩
 
 lemma inhabited_of_mem_sets {f : filter α} {s : set α} (hf : f ≠ ⊥) (hs : s ∈ f^.sets) :
   ∃x, x ∈ s :=
@@ -828,13 +828,13 @@ lemma infi_neq_bot_of_directed {f : ι → filter α}
 let ⟨x⟩ := hn in
 assume h, have he: ∅ ∈ (infi f)^.sets, from h.symm ▸ mem_bot_sets,
 classical.by_cases
-  (assume : nonempty ι,
+  (suppose nonempty ι,
     have ∃i, ∅ ∈ (f i).sets,
       by rw [infi_sets_eq hd this] at he; simp at he; assumption,
     let ⟨i, hi⟩ := this in
     hb i $ bot_unique $
     assume s _, (f i)^.upwards_sets hi $ empty_subset _)
-  (assume : ¬ nonempty ι,
+  (suppose ¬ nonempty ι,
     have univ ⊆ (∅ : set α),
     begin
       rw [←principal_mono, principal_univ, principal_empty, ←h],
@@ -866,7 +866,7 @@ assume a b h, vmap_mono h
 lemma vmap_principal {t : set β} : vmap m (principal t) = principal (vimage m t) :=
 filter_eq $ set.ext $ assume s,
   ⟨assume ⟨u, (hu : t ⊆ u), (b : vimage m u ⊆ s)⟩, subset.trans (vimage_mono hu) b,
-    assume : vimage m t ⊆ s, ⟨t, subset.refl t, this⟩⟩
+    suppose vimage m t ⊆ s, ⟨t, subset.refl t, this⟩⟩
 
 lemma vimage_mem_vmap {f : filter β} {m : α → β} {s : set β} (hs : s ∈ f.sets):
   vimage m s ∈ (vmap m f).sets :=
@@ -1482,7 +1482,7 @@ le_of_inf_eq $ ultrafilter_unique hf h inf_le_left
 
 lemma mem_or_compl_mem_of_ultrafilter (hf : ultrafilter f) (s : set α) :
   s ∈ f.sets ∨ - s ∈ f.sets :=
-or_of_not_implies $ assume : - s ∉ f.sets,
+or_of_not_implies $ suppose - s ∉ f.sets,
   have f ≤ principal s,
     from le_of_ultrafilter hf $ assume h, this $ mem_sets_of_neq_bot $ by simp [*],
   by simp at this; assumption
@@ -1490,7 +1490,7 @@ or_of_not_implies $ assume : - s ∉ f.sets,
 lemma mem_or_mem_of_ultrafilter {s t : set α} (hf : ultrafilter f) (h : s ∪ t ∈ f.sets) :
   s ∈ f.sets ∨ t ∈ f.sets :=
 (mem_or_compl_mem_of_ultrafilter hf s).imp_right
-  (assume : -s ∈ f.sets, f.upwards_sets (inter_mem_sets this h) $
+  (suppose -s ∈ f.sets, f.upwards_sets (inter_mem_sets this h) $
     assume x ⟨hnx, hx⟩, hx.resolve_left hnx)
 
 lemma mem_of_finite_sUnion_ultrafilter {s : set (set α)} (hf : ultrafilter f) (hs : finite s)
@@ -1501,7 +1501,7 @@ begin
   case finite.insert t s' ht' hs' ih {
     simp,
     exact assume h, (mem_or_mem_of_ultrafilter hf h).elim
-      (assume : t ∈ f.sets, ⟨t, this, or.inl rfl⟩)
+      (suppose t ∈ f.sets, ⟨t, this, or.inl rfl⟩)
       (assume h, let ⟨t, hts', ht⟩ := ih h in ⟨t, ht, or.inr hts'⟩) }
 end
 
@@ -1515,7 +1515,7 @@ let ⟨t, ⟨i, hi, h_eq⟩, (ht : t ∈ f.sets)⟩ := mem_of_finite_sUnion_ultr
 lemma ultrafilter_of_split {f : filter α} (hf : f ≠ ⊥) (h : ∀s, s ∈ f.sets ∨ - s ∈ f.sets) :
   ultrafilter f :=
 ⟨hf, assume g hg g_le s hs, (h s).elim id $
-  assume : - s ∈ f.sets,
+  suppose - s ∈ f.sets,
   have s ∩ -s ∈ g.sets, from inter_mem_sets hs (g_le this),
   by simp [empty_in_sets_eq_bot, hg] at this; contradiction⟩
 

--- a/algebra/lattice/fixed_points.lean
+++ b/algebra/lattice/fixed_points.lean
@@ -47,7 +47,7 @@ have Sup s = lfp f,
 this ▸ p_s
 
 lemma monotone_lfp : monotone (@lfp α _) :=
-assume f g, assume : f ≤ g, le_lfp $ assume a, assume : g a ≤ a, lfp_le $ le_trans (‹f ≤ g› a) this
+assume f g, suppose f ≤ g, le_lfp $ assume a, suppose g a ≤ a, lfp_le $ le_trans (‹f ≤ g› a) this
 
 lemma le_gfp {a : α} (h : a ≤ f a) : a ≤ gfp f :=
 le_Sup h
@@ -74,7 +74,7 @@ have Inf s = gfp f,
 this ▸ p_s
 
 lemma monotone_gfp : monotone (@gfp α _) :=
-assume f g, assume : f ≤ g, gfp_le $ assume a, assume : a ≤ f a, le_gfp $ le_trans this (‹f ≤ g› a)
+assume f g, suppose f ≤ g, gfp_le $ assume a, suppose a ≤ f a, le_gfp $ le_trans this (‹f ≤ g› a)
 
 end fixedpoint
 

--- a/algebra/lattice/zorn.lean
+++ b/algebra/lattice/zorn.lean
@@ -127,7 +127,7 @@ end
 lemma chain_closure_total (hc₁ : chain_closure c₁) (hc₂ : chain_closure c₂) : c₁ ⊆ c₂ ∨ c₂ ⊆ c₁ :=
 have c₁ ⊆ c₂ ∨ succ_chain c₂ ⊆ c₁,
   from chain_closure_succ_total_aux hc₁ hc₂ $ assume c₃ hc₃, chain_closure_succ_total hc₃ hc₂,
-or.imp_right (assume : succ_chain c₂ ⊆ c₁, subset.trans succ_increasing this) this
+or.imp_right (suppose succ_chain c₂ ⊆ c₁, subset.trans succ_increasing this) this
 
 lemma chain_closure_succ_fixpoint (hc₁ : chain_closure c₁) (hc₂ : chain_closure c₂)
   (h_eq : succ_chain c₂ = c₂) : c₁ ⊆ c₂ :=
@@ -145,7 +145,7 @@ lemma chain_closure_succ_fixpoint_iff (hc : chain_closure c) :
 ⟨assume h, subset.antisymm
     (subset_sUnion_of_mem hc)
     (chain_closure_succ_fixpoint chain_closure_closure hc h),
-  assume : c = ⋃₀{c : set α | chain_closure c},
+  suppose c = ⋃₀{c : set α | chain_closure c},
   subset.antisymm
     (calc succ_chain c ⊆ ⋃₀{c : set α | chain_closure c} :
         subset_sUnion_of_mem $ chain_closure.succ hc
@@ -162,8 +162,8 @@ begin
     exact assume c₁ ⟨t₁, ht₁, (hc₁ : c₁ ∈ t₁)⟩ c₂ ⟨t₂, ht₂, (hc₂ : c₂ ∈ t₂)⟩ hneq,
       have t₁ ⊆ t₂ ∨ t₂ ⊆ t₁, from chain_closure_total (hs _ ht₁) (hs _ ht₂),
       or.elim this
-        (assume : t₁ ⊆ t₂, h t₂ ht₂ c₁ (this hc₁) c₂ hc₂ hneq)
-        (assume : t₂ ⊆ t₁, h t₁ ht₁ c₁ hc₁ c₂ (this hc₂) hneq) }
+        (suppose t₁ ⊆ t₂, h t₂ ht₂ c₁ (this hc₁) c₂ hc₂ hneq)
+        (suppose t₂ ⊆ t₁, h t₁ ht₁ c₁ hc₁ c₂ (this hc₂) hneq) }
 end
 
 def max_chain := (⋃₀ {c | chain_closure c})
@@ -174,7 +174,7 @@ There exists a maximal totally ordered subset of `α`.
 Note that we do not require `α` to be partially ordered by `r`. -/
 lemma max_chain_spec : is_max_chain max_chain :=
 classical.by_contradiction $
-assume : ¬ is_max_chain (⋃₀ {c | chain_closure c}),
+suppose ¬ is_max_chain (⋃₀ {c | chain_closure c}),
 have super_chain (⋃₀ {c | chain_closure c}) (succ_chain (⋃₀ {c | chain_closure c})),
   from super_of_not_max (chain_chain_closure chain_closure_closure) this,
 let ⟨h₁, h₂, (h₃ : (⋃₀ {c | chain_closure c}) ≠ succ_chain (⋃₀ {c | chain_closure c}))⟩ := this in

--- a/algebra/ring.lean
+++ b/algebra/ring.lean
@@ -66,7 +66,7 @@ section
   /-
   dvd.elim Hdvd
     (assume d,
-      assume : a * c = a * b * d,
+      suppose a * c = a * b * d,
       have b * d = c, from eq_of_mul_eq_mul_left Ha begin rewrite ←mul.assoc, symmetry, exact this end,
       dvd.intro this)
   -/
@@ -76,7 +76,7 @@ section
   /-
   dvd.elim Hdvd
     (assume d,
-      assume : c * a = b * a * d,
+      suppose c * a = b * a * d,
       have b * d * a = c * a, from by rewrite [mul.right_comm, ←this],
       have b * d = c, from eq_of_mul_eq_mul_right Ha this,
       dvd.intro this)

--- a/data/int/order.lean
+++ b/data/int/order.lean
@@ -91,9 +91,9 @@ have a * b > 0, by rewrite H'; apply trivial,
 have b > 0, from pos_of_mul_pos_left this H,
 have a > 0, from pos_of_mul_pos_right `a * b > 0` (le_of_lt `b > 0`),
 or.elim (le_or_gt a 1)
-  (assume : a ≤ 1,
+  (suppose a ≤ 1,
     show a = 1, from le.antisymm this (add_one_le_of_lt `a > 0`))
-  (assume : a > 1,
+  (suppose a > 1,
     have a * b ≥ 2 * 1,
       from mul_le_mul (add_one_le_of_lt `a > 1`) (add_one_le_of_lt `b > 0`) trivial H,
     have false, by rewrite [H' at this]; exact this,
@@ -111,7 +111,7 @@ eq_one_of_mul_eq_self_left Hpos (!mul.comm ▸ H)
 theorem eq_one_of_dvd_one {a : ℤ} (H : a ≥ 0) (H' : a ∣ 1) : a = 1 :=
 dvd.elim H'
   (assume b,
-    assume : 1 = a * b,
+    suppose 1 = a * b,
     eq_one_of_mul_eq_one_right H this⁻¹)
 
 theorem exists_least_of_bdd {P : ℤ → Prop} [HP : decidable_pred P]

--- a/data/list/basic.lean
+++ b/data/list/basic.lean
@@ -125,10 +125,10 @@ assume n, if_neg n
 @[simp]
 theorem index_of_of_not_mem {l : list α} {a : α} : ¬a ∈ l → index_of a l = length l :=
 list.rec_on l
-   (assume : ¬a ∈ [], rfl)
+   (suppose ¬a ∈ [], rfl)
    (assume b l,
       assume ih : ¬a ∈ l → index_of a l = length l,
-      assume : ¬a ∈ b::l,
+      suppose ¬a ∈ b::l,
       have ¬a = b ∧ ¬a ∈ l, begin rw [mem_cons_iff, not_or_iff] at this, exact this end,
       show index_of a (b::l) = length (b::l),
         begin rw [index_of_cons, if_neg this^.left, ih this^.right], reflexivity end)
@@ -139,8 +139,8 @@ list.rec_on l
   (assume b l, assume ih : index_of a l ≤ length l,
    show index_of a (b::l) ≤ length (b::l), from
      decidable.by_cases
-       (assume : a = b, begin simp [this, index_of_cons_of_eq l (eq.refl b)], apply zero_le end)
-       (assume : a ≠ b, begin rw [index_of_cons_of_ne l this], apply succ_le_succ ih end))
+       (suppose a = b, begin simp [this, index_of_cons_of_eq l (eq.refl b)], apply zero_le end)
+       (suppose a ≠ b, begin rw [index_of_cons_of_ne l this], apply succ_le_succ ih end))
 
 lemma not_mem_of_index_of_eq_length : ∀ {a : α} {l : list α}, index_of a l = length l → a ∉ l
 | a []        := by simp
@@ -310,8 +310,8 @@ rfl
 lemma count_cons' (a b : α) (l : list α) :
   count a (b :: l) = count a l + (if a = b then 1 else 0) :=
 decidable.by_cases
-  (assume : a = b, begin rw [count_cons, if_pos this, if_pos this] end)
-  (assume : a ≠ b, begin rw [count_cons, if_neg this, if_neg this], reflexivity end)
+  (suppose a = b, begin rw [count_cons, if_pos this, if_pos this] end)
+  (suppose a ≠ b, begin rw [count_cons, if_neg this, if_neg this], reflexivity end)
 
 
 @[simp]
@@ -324,8 +324,8 @@ if_neg h
 
 lemma count_cons_ge_count (a b : α) (l : list α) : count a (b :: l) ≥ count a l :=
 decidable.by_cases
-  (assume : a = b, begin subst b, rewrite count_cons_self, apply le_succ end)
-  (assume : a ≠ b, begin rw (count_cons_of_ne this), apply le_refl end)
+  (suppose a = b, begin subst b, rewrite count_cons_self, apply le_succ end)
+  (suppose a ≠ b, begin rw (count_cons_of_ne this), apply le_refl end)
 
 -- TODO(Jeremy): without the reflexivity, this yields the goal "1 = 1". the first is from has_one,
 -- the second is succ 0. Make sure the simplifier can eventually handle this.
@@ -337,9 +337,9 @@ by simp
 lemma count_append (a : α) : ∀ l₁ l₂, count a (l₁ ++ l₂) = count a l₁ + count a l₂
 | []      l₂ := begin rw [nil_append, count_nil, zero_add] end
 | (b::l₁) l₂ := decidable.by_cases
-  (assume : a = b, by rw [←this, cons_append, count_cons_self, count_cons_self, succ_add,
+  (suppose a = b, by rw [←this, cons_append, count_cons_self, count_cons_self, succ_add,
                          count_append])
-  (assume : a ≠ b, by rw [cons_append, count_cons_of_ne this, count_cons_of_ne this, count_append])
+  (suppose a ≠ b, by rw [cons_append, count_cons_of_ne this, count_cons_of_ne this, count_append])
 
 @[simp]
 lemma count_concat (a : α) (l : list α) : count a (concat l a) = succ (count a l) :=
@@ -348,8 +348,8 @@ by rw [concat_eq_append, count_append, count_singleton]
 lemma mem_of_count_pos : ∀ {a : α} {l : list α}, count a l > 0 → a ∈ l
 | a []     h := absurd h (lt_irrefl _)
 | a (b::l) h := decidable.by_cases
-  (assume : a = b, begin subst b, apply mem_cons_self end)
-  (assume : a ≠ b,
+  (suppose a = b, begin subst b, apply mem_cons_self end)
+  (suppose a ≠ b,
    have count a l > 0, begin rw [count_cons_of_ne this] at h, exact h end,
    have a ∈ l,    from mem_of_count_pos this,
    show a ∈ b::l, from mem_cons_of_mem _ this)
@@ -357,8 +357,8 @@ lemma mem_of_count_pos : ∀ {a : α} {l : list α}, count a l > 0 → a ∈ l
 lemma count_pos_of_mem : ∀ {a : α} {l : list α}, a ∈ l → count a l > 0
 | a []     h := absurd h (not_mem_nil _)
 | a (b::l) h := or.elim h
-  (assume : a = b, begin subst b, rw count_cons_self, apply zero_lt_succ end)
-  (assume : a ∈ l, calc
+  (suppose a = b, begin subst b, rw count_cons_self, apply zero_lt_succ end)
+  (suppose a ∈ l, calc
    count a (b::l) ≥ count a l : count_cons_ge_count _ _ _
            ...    > 0         : count_pos_of_mem this)
 
@@ -376,7 +376,7 @@ have ∀ n, count a l = n → count a l = 0,
 this (count a l) rfl
 
 lemma not_mem_of_count_eq_zero {a : α} {l : list α} (h : count a l = 0) : a ∉ l :=
-assume : a ∈ l,
+suppose a ∈ l,
 have count a l > 0, from count_pos_of_mem this,
 show false, begin rw h at this, exact nat.not_lt_zero _ this end
 

--- a/data/list/comb.lean
+++ b/data/list/comb.lean
@@ -104,7 +104,7 @@ theorem all_eq_tt_of_forall {p : α → bool} : ∀ {l : list α}, (∀ a ∈ l,
 theorem forall_mem_eq_tt_of_all_eq_tt {p : α → bool} :
   ∀ {l : list α}, all l p = tt → ∀ a ∈ l, p a = tt
 | []     h := assume a h, absurd h (not_mem_nil a)
-| (b::l) h := assume a, assume : a ∈ b::l,
+| (b::l) h := assume a, suppose a ∈ b::l,
               begin
                 simp [bool.band_eq_tt] at h, cases h with h₁ h₂,
                 simp at this, cases this with h' h',
@@ -125,8 +125,8 @@ theorem any_of_mem {p : α → bool} {a : α} : ∀ {l : list α}, a ∈ l → p
 | []     i h := absurd i (not_mem_nil a)
 | (b::l) i h :=
   or.elim (eq_or_mem_of_mem_cons i)
-    (assume : a = b, begin simp [this^.symm, bool.bor_eq_tt], exact (or.inl h) end)
-    (assume : a ∈ l, begin
+    (suppose a = b, begin simp [this^.symm, bool.bor_eq_tt], exact (or.inl h) end)
+    (suppose a ∈ l, begin
                       cases (eq_or_mem_of_mem_cons i) with h' h',
                       { simp [h'^.symm, h] },
                       simp [bool.bor_eq_tt, any_of_mem h', h]
@@ -152,8 +152,8 @@ assume x xnil, absurd xnil (not_mem_nil x)
 theorem forall_mem_cons {p : α → Prop} {a : α} {l : list α} (pa : p a) (h : ∀ x ∈ l, p x) :
   ∀ x ∈ a :: l, p x :=
 assume x xal, or.elim (eq_or_mem_of_mem_cons xal)
-  (assume : x = a, by simp [this, pa])
-  (assume : x ∈ l, by simp [this, h])
+  (suppose x = a, by simp [this, pa])
+  (suppose x ∈ l, by simp [this, h])
 
 theorem of_forall_mem_cons {p : α → Prop} {a : α} {l : list α} (h : ∀ x ∈ a :: l, p x) : p a :=
 h a (by simp)
@@ -185,8 +185,8 @@ theorem or_exists_of_exists_mem_cons {p : α → Prop} {a : α} {l : list α} (h
   p a ∨ ∃ x ∈ l, p x :=
 bexists.elim h (λ x xal px,
   or.elim (eq_or_mem_of_mem_cons xal)
-    (assume : x = a, begin rw ←this, simp [px] end)
-    (assume : x ∈ l, or.inr (bexists.intro x this px)))
+    (suppose x = a, begin rw ←this, simp [px] end)
+    (suppose x ∈ l, or.inr (bexists.intro x this px)))
 
 @[simp]
 theorem exists_mem_cons_iff (p : α → Prop) (a : α) (l : list α) :
@@ -343,10 +343,10 @@ theorem mem_of_mem_product_left {a : α} {b : β} : ∀ {l₁ l₂}, (a, b) ∈ 
 | []      l₂ h := absurd h (not_mem_nil _)
 | (x::l₁) l₂ h :=
   or.elim (mem_or_mem_of_mem_append h)
-    (assume : (a, b) ∈ map (λ b, (x, b)) l₂,
+    (suppose (a, b) ∈ map (λ b, (x, b)) l₂,
        have a = x, from eq_of_mem_map_pair₁ this,
        begin rw this, apply mem_cons_self end)
-    (assume : (a, b) ∈ product l₁ l₂,
+    (suppose (a, b) ∈ product l₁ l₂,
       have a ∈ l₁, from mem_of_mem_product_left this,
       mem_cons_of_mem _ this)
 
@@ -354,9 +354,9 @@ theorem mem_of_mem_product_right {a : α} {b : β} : ∀ {l₁ l₂}, (a, b) ∈
 | []      l₂ h := absurd h (not_mem_nil ((a, b)))
 | (x::l₁) l₂ h :=
   or.elim (mem_or_mem_of_mem_append h)
-    (assume : (a, b) ∈ map (λ b, (x, b)) l₂,
+    (suppose (a, b) ∈ map (λ b, (x, b)) l₂,
       mem_of_mem_map_pair₁ this)
-    (assume : (a, b) ∈ product l₁ l₂,
+    (suppose (a, b) ∈ product l₁ l₂,
       mem_of_mem_product_right this)
 
 theorem length_product :
@@ -515,7 +515,7 @@ def list_nat_equiv_nat : list nat ≃ nat :=
 mk to_nat of_nat of_nat_to_nat to_nat_of_nat
 
 def list_equiv_self_of_equiv_nat {α : Type} : α ≃ nat → list α ≃ α :=
-assume : α ≃ nat, calc
+suppose α ≃ nat, calc
   list α ≃ list nat : list_equiv_of_equiv this
      ... ≃ nat      : list_nat_equiv_nat
      ... ≃ α        : this

--- a/data/list/perm.lean
+++ b/data/list/perm.lean
@@ -241,7 +241,7 @@ variable [decα : decidable_eq α]
 include decα
 
 theorem count_eq_count_of_perm {l₁ l₂ : list α} : l₁ ~ l₂ → ∀ a, count a l₁ = count a l₂ :=
-assume : l₁ ~ l₂, perm.rec_on this
+suppose l₁ ~ l₂, perm.rec_on this
   (λ a, rfl)
   (λ x l₁ l₂ p h a, begin simp [count_cons', h a] end)
   (λ x y l a, begin simp [count_cons'] end)
@@ -421,8 +421,8 @@ theorem qeq_split {a : α} : ∀ {l l' : list α}, l'≈a|l → ∃ l₁ l₂, l
 --  have b ∈ v,    from s (or.inr binl),
 --  have b ∈ a::u, from mem_cons_of_qeq q this,
 --  or.elim (eq_or_mem_of_mem_cons this)
---    (assume : b = a, begin subst b, contradiction end)
---    (assume : b ∈ u, this)
+--    (suppose b = a, begin subst b, contradiction end)
+--    (suppose b ∈ u, this)
 --end qeq
 
 theorem perm_inv_core {l₁ l₂ : list α} (p' : l₁ ~ l₂) : ∀ {a s₁ s₂}, l₁≈a|s₁ → l₂≈a|s₂ → s₁ ~ s₂ :=
@@ -571,7 +571,7 @@ assume p, perm_induction_on p
             have x ∈ t₁, from or_resolve_right xinyt₁ xney,
             have x ∈ t₂, from mem_of_mem_erase_dup (mem_of_perm r (mem_erase_dup this)),
             have y ∉ x::t₂, from
-              assume : y ∈ x::t₂, or.elim (eq_or_mem_of_mem_cons this)
+              suppose y ∈ x::t₂, or.elim (eq_or_mem_of_mem_cons this)
                 (λ h, absurd h (ne.symm xney))
                 (λ h, absurd h nyint₂),
             begin
@@ -739,36 +739,36 @@ theorem perm_ext : ∀ {l₁ l₂ : list α}, nodup l₁ → nodup l₂ → (∀
   have dt₂'     : nodup (a₁::(s₁++s₂)), from nodup_head (begin rw [t₂_eq] at d₂, exact d₂ end),
   have eqv      : ∀a, a ∈ t₁ ↔ a ∈ s₁++s₂, from
     assume a, iff.intro
-      (assume :  a ∈ t₁,
+      (suppose  a ∈ t₁,
          have a ∈ a₂::t₂,       from iff.mp (e a) (mem_cons_of_mem _ this),
          have a ∈ s₁++(a₁::s₂), begin rw [t₂_eq] at this, exact this end,
          or.elim (mem_or_mem_of_mem_append this)
-           (assume : a ∈ s₁, mem_append_left s₂ this)
-           (assume : a ∈ a₁::s₂, or.elim (eq_or_mem_of_mem_cons this)
-             (assume : a = a₁,
+           (suppose a ∈ s₁, mem_append_left s₂ this)
+           (suppose a ∈ a₁::s₂, or.elim (eq_or_mem_of_mem_cons this)
+             (suppose a = a₁,
                have a₁ ∉ t₁, from not_mem_of_nodup_cons d₁,
                begin subst a, contradiction end)
-             (assume : a ∈ s₂, mem_append_right s₁ this)))
-      (assume : a ∈ s₁ ++ s₂, or.elim (mem_or_mem_of_mem_append this)
-        (assume : a ∈ s₁,
+             (suppose a ∈ s₂, mem_append_right s₁ this)))
+      (suppose a ∈ s₁ ++ s₂, or.elim (mem_or_mem_of_mem_append this)
+        (suppose a ∈ s₁,
            have a ∈ a₂::t₂, from begin rw [t₂_eq], exact (mem_append_left _ this) end,
            have a ∈ a₁::t₁, from iff.mpr (e a) this,
            or.elim (eq_or_mem_of_mem_cons this)
-             (assume : a = a₁,
+             (suppose a = a₁,
                 have a₁ ∉ s₁++s₂, from not_mem_of_nodup_cons dt₂',
                 have a₁ ∉ s₁,     from not_mem_of_not_mem_append_left this,
                 begin subst a, contradiction end)
-             (assume : a ∈ t₁, this))
-        (assume : a ∈ s₂,
+             (suppose a ∈ t₁, this))
+        (suppose a ∈ s₂,
            have a ∈ a₂::t₂, from begin rw [t₂_eq],
                                        exact (mem_append_right _ (mem_cons_of_mem _ this)) end,
            have a ∈ a₁::t₁, from iff.mpr (e a) this,
            or.elim (eq_or_mem_of_mem_cons this)
-             (assume : a = a₁,
+             (suppose a = a₁,
                have a₁ ∉ s₁++s₂, from not_mem_of_nodup_cons dt₂',
                have a₁ ∉ s₂, from not_mem_of_not_mem_append_right this,
                begin subst a, contradiction end)
-             (assume : a ∈ t₁, this))),
+             (suppose a ∈ t₁, this))),
   have ds₁s₂ : nodup (s₁++s₂), from nodup_of_nodup_cons dt₂',
   have nodup t₁, from nodup_of_nodup_cons d₁,
   calc a₁::t₁ ~ a₁::(s₁++s₂) : skip a₁ (perm_ext this ds₁s₂ eqv)
@@ -784,14 +784,14 @@ assume h, perm.rec_on h
     have nodup l₁, from nodup_of_nodup_cons nd,
     have nodup l₂, from ih this,
     have a ∉ l₁,   from not_mem_of_nodup_cons nd,
-    have a ∉ l₂,   from assume : a ∈ l₂, absurd (mem_of_perm (perm.symm p) this) ‹a ∉ l₁›,
+    have a ∉ l₂,   from suppose a ∈ l₂, absurd (mem_of_perm (perm.symm p) this) ‹a ∉ l₁›,
     nodup_cons ‹a ∉ l₂› ‹nodup l₂›)
   (λ x y l₁ nd,
     have nodup (x::l₁),    from nodup_of_nodup_cons nd,
     have nodup l₁,         from nodup_of_nodup_cons this,
     have x ∉ l₁,           from not_mem_of_nodup_cons ‹nodup (x::l₁)›,
     have y ∉ x::l₁,        from not_mem_of_nodup_cons nd,
-    have x ≠ y,            from assume : x = y,
+    have x ≠ y,            from suppose x = y,
                                 begin subst x, apply absurd (mem_cons_self _ _), apply ‹y ∉ y::l₁› end, -- this line used to be "exact absurd (mem_cons_self _ _) ‹y ∉ y::l₁›, but it's now a syntax error
     have y ∉ l₁,           from not_mem_of_not_mem_cons ‹y ∉ x::l₁›,
     have x ∉ y::l₁,        from not_mem_cons_of_ne_of_not_mem ‹x ≠ y› ‹x ∉ l₁›,
@@ -838,9 +838,9 @@ assume u, perm.rec_on u
     assume u' : l₁' ~ l₂',
     assume u'' : filter p l₁' ~ filter p l₂',
     decidable.by_cases
-      (assume : p x, begin rw [filter_cons_of_pos _ this, filter_cons_of_pos _ this],
+      (suppose p x, begin rw [filter_cons_of_pos _ this, filter_cons_of_pos _ this],
                           apply perm.skip, apply u'' end)
-      (assume : ¬ p x, begin rw [filter_cons_of_neg _ this, filter_cons_of_neg _ this],
+      (suppose ¬ p x, begin rw [filter_cons_of_neg _ this, filter_cons_of_neg _ this],
                             apply u'' end))
   (assume x y l,
     decidable.by_cases

--- a/data/list/set.lean
+++ b/data/list/set.lean
@@ -224,7 +224,7 @@ theorem length_upto : ∀ n, length (upto n) = n
 | (succ n) := begin rw [upto_succ, length_cons, length_upto] end
 
 theorem upto_ne_nil_of_ne_zero {n : ℕ} (h : n ≠ 0) : upto n ≠ nil :=
-assume : upto n = nil,
+suppose upto n = nil,
 have upto n = upto 0, from upto_nil ▸ this,
 have n = 0, from calc
      n = length (upto n) : by rw length_upto
@@ -460,9 +460,9 @@ theorem disjoint_of_nodup_append : ∀ {l₁ l₂ : list α}, nodup (l₁++l₂)
   have nodup (x::(xs++l₂)),    from d,
   have x ∉ xs++l₂,             from not_mem_of_nodup_cons this,
   have nxinl₂ : x ∉ l₂,        from not_mem_of_not_mem_append_right this,
-  assume a, assume : a ∈ x::xs,
+  assume a, suppose a ∈ x::xs,
     or.elim (eq_or_mem_of_mem_cons this)
-      (assume : a = x, eq.symm this ▸ nxinl₂)
+      (suppose a = x, eq.symm this ▸ nxinl₂)
       (assume ainxs : a ∈ xs,
         have nodup (x::(xs++l₂)), from d,
         have nodup (xs++l₂),      from nodup_of_nodup_cons this,

--- a/data/list/sort.lean
+++ b/data/list/sort.lean
@@ -139,10 +139,10 @@ theorem sorted_ordered_insert (a : α) : ∀ l, sorted r l → sorted r (ordered
     begin
       simp [ordered_insert, if_pos, h'],
       exact have ∀ c ∈ b :: l, a ≼ c, from
-        assume c, assume : c ∈ b :: l,
+        assume c, suppose c ∈ b :: l,
         or.elim (eq_or_mem_of_mem_cons this)
-          (assume : c = b, this^.symm ▸ ‹a ≼ b›)
-          (assume : c ∈ l, transr ‹a ≼ b› (h₀ _ this)),
+          (suppose c = b, this^.symm ▸ ‹a ≼ b›)
+          (suppose c ∈ l, transr ‹a ≼ b› (h₀ _ this)),
       show sorted r (a :: b :: l), from sorted_cons r h this
    end
   else
@@ -152,11 +152,11 @@ theorem sorted_ordered_insert (a : α) : ∀ l, sorted r l → sorted r (ordered
       exact have h₁ : sorted r (ordered_insert r a l), from sorted_ordered_insert l ‹sorted r l›,
       have h₂ : ∀ c ∈ ordered_insert r a l, b ≼ c, from
         assume c,
-        assume : c ∈ ordered_insert r a l,
+        suppose c ∈ ordered_insert r a l,
         have c ∈ a  :: l, from (mem_ordered_insert_iff r c a l)^.mp this,
         or.elim (eq_or_mem_of_mem_cons this)
-          (assume : c = a, begin rw this, exact ‹b ≼ a› end)
-          (assume : c ∈ l, h₀ c this),
+          (suppose c = a, begin rw this, exact ‹b ≼ a› end)
+          (suppose c ∈ l, h₀ c this),
       show sorted r (b :: ordered_insert r a l), from sorted_cons r h₁ h₂
     end
 
@@ -367,11 +367,11 @@ private def sorted_merge.F :
         intros c hc,
         rw mem_merge_iff at hc,
         exact or.elim hc
-          (assume : c ∈ l, show a ≼ c, from h₁₀ c this)
-          (assume : c ∈ b :: l',
+          (suppose c ∈ l, show a ≼ c, from h₁₀ c this)
+          (suppose c ∈ b :: l',
             or.elim (eq_or_mem_of_mem_cons this)
-              (assume : c = b, show a ≼ c, from this^.symm ▸ ‹a ≼ b›)
-              (assume : c ∈ l', show a ≼ c, from transr ‹a ≼ b› (h₂₀ c this)))
+              (suppose c = b, show a ≼ c, from this^.symm ▸ ‹a ≼ b›)
+              (suppose c ∈ l', show a ≼ c, from transr ‹a ≼ b› (h₂₀ c this)))
       end,
       show sorted r (a :: merge r (l, b :: l')), from sorted_cons r h₃ h₄
     end
@@ -386,11 +386,11 @@ private def sorted_merge.F :
         intros c hc,
         rw mem_merge_iff at hc,
         exact or.elim hc
-          (assume : c ∈ a :: l,
+          (suppose c ∈ a :: l,
             or.elim (eq_or_mem_of_mem_cons this)
-              (assume : c = a, show b ≼ c, from this^.symm ▸ ‹b ≼ a›)
-              (assume : c ∈ l, show b ≼ c, from transr ‹b ≼ a› (h₁₀ c this)))
-          (assume : c ∈ l', show b ≼ c, from h₂₀ c this)
+              (suppose c = a, show b ≼ c, from this^.symm ▸ ‹b ≼ a›)
+              (suppose c ∈ l, show b ≼ c, from transr ‹b ≼ a› (h₁₀ c this)))
+          (suppose c ∈ l', show b ≼ c, from h₂₀ c this)
       end,
       show sorted r (b :: merge r (a :: l, l')), from sorted_cons r h₃ h₄
     end

--- a/data/nat/sub.lean
+++ b/data/nat/sub.lean
@@ -12,27 +12,27 @@ namespace nat
 
 protected theorem le_sub_add (n m : ℕ) : n ≤ n - m + m :=
 or.elim (le_total n m)
-  (assume : n ≤ m, begin rw [sub_eq_zero_of_le this, zero_add], exact this end)
-  (assume : m ≤ n, begin rw (nat.sub_add_cancel this) end)
+  (suppose n ≤ m, begin rw [sub_eq_zero_of_le this, zero_add], exact this end)
+  (suppose m ≤ n, begin rw (nat.sub_add_cancel this) end)
 
 protected theorem sub_eq_of_eq_add {n m k : ℕ} (h : k = n + m) : k - n = m :=
 begin rw [h, nat.add_sub_cancel_left] end
 
 protected theorem lt_of_sub_pos {m n : ℕ} (h : n - m > 0) : m < n :=
 lt_of_not_ge
-  (assume : m ≥ n,
+  (suppose m ≥ n,
     have n - m = 0, from sub_eq_zero_of_le this,
     begin rw this at h, exact lt_irrefl _ h end)
 
 protected theorem lt_of_sub_lt_sub_right {n m k : ℕ} (h : n - k < m - k) : n < m :=
 lt_of_not_ge
-  (assume : m ≤ n,
+  (suppose m ≤ n,
     have m - k ≤ n - k, from nat.sub_le_sub_right this _,
     not_le_of_gt h this)
 
 protected theorem lt_of_sub_lt_sub_left {n m k : ℕ} (h : n - m < n - k) : k < m :=
 lt_of_not_ge
-  (assume : m ≤ k,
+  (suppose m ≤ k,
     have n - k ≤ n - m, from nat.sub_le_sub_left _ this,
     not_le_of_gt h this)
 
@@ -119,9 +119,9 @@ calc
 
 protected theorem sub_lt_sub_add_sub (n m k : ℕ) : n - k ≤ (n - m) + (m - k) :=
 or.elim (le_total k m)
-  (assume : k ≤ m,
+  (suppose k ≤ m,
     begin rw ←nat.add_sub_assoc this, apply nat.sub_le_sub_right, apply nat.le_sub_add end)
-  (assume : k ≥ m,
+  (suppose k ≥ m,
     begin rw [sub_eq_zero_of_le this, add_zero], apply nat.sub_le_sub_left, exact this end)
 
 theorem dist.triangle_inequality (n m k : ℕ) : dist n k ≤ dist n m + dist m k :=
@@ -141,9 +141,9 @@ by rw [mul_comm k n, mul_comm k m, dist_mul_right, mul_comm]
 --sorry
 /-
 or.elim (lt_or_ge i j)
-  (assume : i < j,
+  (suppose i < j,
     by rw [max_eq_right_of_lt this, min_eq_left_of_lt this, dist_eq_sub_of_lt this])
-  (assume : i ≥ j,
+  (suppose i ≥ j,
     by rw [max_eq_left this , min_eq_right this, dist_eq_sub_of_ge this])
 -/
 
@@ -152,10 +152,10 @@ by simp [dist.def, succ_sub_succ]
 
 lemma dist_pos_of_ne {i j : nat} : i ≠ j → dist i j > 0 :=
 assume hne, nat.lt_by_cases
-  (assume : i < j,
+  (suppose i < j,
      begin rw [dist_eq_sub_of_le (le_of_lt this)], apply nat.sub_pos_of_lt this end)
-  (assume : i = j, by contradiction)
-  (assume : i > j,
+  (suppose i = j, by contradiction)
+  (suppose i > j,
      begin rw [dist_eq_sub_of_ge (le_of_lt this)], apply nat.sub_pos_of_lt this end)
 
 end nat

--- a/data/rat.lean
+++ b/data/rat.lean
@@ -38,7 +38,7 @@ universes u
 variables {α : Type u} [linear_ordered_ring α] {a b : α}
 
 lemma mul_nonneg_iff_right_nonneg_of_pos (h : 0 < a) : 0 ≤ b * a ↔ 0 ≤ b :=
-⟨assume : 0 ≤ b * a, nonneg_of_mul_nonneg_right this h, assume : 0 ≤ b, mul_nonneg this $ le_of_lt h⟩
+⟨suppose 0 ≤ b * a, nonneg_of_mul_nonneg_right this h, suppose 0 ≤ b, mul_nonneg this $ le_of_lt h⟩
 
 end ordered_ring
 
@@ -130,9 +130,9 @@ instance : has_mul ℚ := ⟨rat.mul⟩
 
 private def inv' : rat.num_denum → ℚ
 | ⟨n, ⟨d, h⟩⟩ := linear_order_cases_on n 0
-  (assume : n = 0, 0)
-  (assume : n < 0, ⟦⟨-d, ⟨-n, neg_pos_of_neg this⟩⟩⟧)
-  (assume : n > 0, ⟦⟨d, ⟨n, this⟩⟩⟧)
+  (suppose n = 0, 0)
+  (suppose n < 0, ⟦⟨-d, ⟨-n, neg_pos_of_neg this⟩⟩⟧)
+  (suppose n > 0, ⟦⟨d, ⟨n, this⟩⟩⟧)
 
 private lemma inv'_zero : Π{d : {d:ℤ // d > 0}}, inv' ⟨0, d⟩ = 0
 | ⟨d, p⟩ := linear_order_cases_on_eq rfl
@@ -147,13 +147,13 @@ protected def inv : ℚ → ℚ :=
 quotient.lift inv' $ λ⟨n₁, ⟨d₁, h₁⟩⟩ ⟨n₂, ⟨d₂, h₂⟩⟩,
   assume h_eq : n₁ * d₂ = n₂ * d₁,
   linear_order_cases_on n₁ 0
-    (assume : n₁ = 0,
+    (suppose n₁ = 0,
       have n₂ * d₁ = 0,
         by simp [this] at h_eq; simp [h_eq],
       have n₂ = 0,
         from (eq_zero_or_eq_zero_of_mul_eq_zero this)^.resolve_right $ (ne_of_lt h₁)^.symm,
       by simp [this, ‹n₁ = 0›, inv'_zero])
-    (assume : n₁ < 0,
+    (suppose n₁ < 0,
       have n₂ * d₁ < 0,
         from h_eq ▸ mul_neg_of_neg_of_pos this ‹0 < d₂›,
       have n₂ < 0,
@@ -163,7 +163,7 @@ quotient.lift inv' $ λ⟨n₁, ⟨d₁, h₁⟩⟩ ⟨n₂, ⟨d₂, h₂⟩⟩
         apply quotient.sound,
         simp [h_eq]
       end)
-    (assume : n₁ > 0,
+    (suppose n₁ > 0,
       have n₂ * d₁ > 0,
         from h_eq ▸ mul_pos this ‹0 < d₂›,
       have n₂ > 0,
@@ -240,12 +240,12 @@ protected lemma mul_inv_cancel : a ≠ 0 → a * a⁻¹ = 1 :=
 quotient.induction_on a $ λ⟨n, ⟨d, h⟩⟩ neq0,
 let a : rat.num_denum := ⟨n, ⟨d, h⟩⟩ in
 linear_order_cases_on n 0
-  (assume : n = 0, by rw [this, @eq_zero_of_rat_eq_zero ⟨0, ⟨d, h⟩⟩ rfl] at neq0; contradiction)
-  (assume : n < 0,
+  (suppose n = 0, by rw [this, @eq_zero_of_rat_eq_zero ⟨0, ⟨d, h⟩⟩ rfl] at neq0; contradiction)
+  (suppose n < 0,
     have @has_inv.inv rat _ ⟦a⟧ = ⟦⟨-d, ⟨-n, neg_pos_of_neg this⟩⟩⟧,
       from @inv'_neg n d h _,
     begin simp [this], apply quotient.sound, simp [rat.rel] end)
-  (assume : n > 0,
+  (suppose n > 0,
     have @has_inv.inv rat _ ⟦a⟧ = ⟦⟨d, ⟨n, this⟩⟩⟧,
       from @inv'_pos n d h _,
     begin simp [this], apply quotient.sound, simp [rat.rel] end)
@@ -325,8 +325,8 @@ instance : linear_strong_order_pair ℚ :=
 { le              := rat.le,
   lt              := λa b, a ≤ b ∧ a ≠ b,
   le_iff_lt_or_eq := assume a b,
-    ⟨assume : a ≤ b, if h : a = b then or.inr h else or.inl ⟨this, h⟩,
-      or.rec and.left (assume : a = b, show a ≤ b, from this ▸ rat.le_refl _)⟩,
+    ⟨suppose a ≤ b, if h : a = b then or.inr h else or.inl ⟨this, h⟩,
+      or.rec and.left (suppose a = b, show a ≤ b, from this ▸ rat.le_refl _)⟩,
   lt_irrefl       := assume a ⟨_, h⟩, h rfl,
   le_refl         := rat.le_refl,
   le_trans        := assume a b c h_ab h_bc,
@@ -348,7 +348,7 @@ quotient.induction_on a $ assume ⟨n, ⟨d, h⟩⟩ _, show 0 ≤ n * 1 + (- 0)
   by simp; assumption
 
 protected def nonneg_of_zero_le : 0 ≤ a → rat.nonneg a :=
-quotient.induction_on a $ assume ⟨n, ⟨d, h⟩⟩, assume : 0 ≤ n * 1 + (- 0) * d,
+quotient.induction_on a $ assume ⟨n, ⟨d, h⟩⟩, suppose 0 ≤ n * 1 + (- 0) * d,
   by simp at this; assumption
 
 instance : discrete_linear_ordered_field ℚ :=

--- a/data/set/basic.lean
+++ b/data/set/basic.lean
@@ -730,7 +730,7 @@ theorem mem_sUnion_eq {x : α} {S : set (set α)} : x ∈ ⋃₀ S = (∃t ∈ S
 theorem not_mem_of_not_mem_sUnion {x : α} {t : set α} {S : set (set α)}
     (hx : x ∉ ⋃₀ S) (ht : t ∈ S) :
   x ∉ t :=
-assume : x ∈ t,
+suppose x ∈ t,
 have x ∈ ⋃₀ S, from mem_sUnion this ht,
 show false, from hx this
 
@@ -785,11 +785,11 @@ theorem sInter_image (f : α → set β) (s : set α) : ⋂₀ (f '' s) = ⋂ x 
 theorem compl_sUnion (S : set (set α)) :
   - ⋃₀ S = ⋂₀ (compl '' S) :=
 set.ext $ assume x,
-  ⟨assume : ¬ (∃s∈S, x ∈ s), assume s h,
+  ⟨suppose ¬ (∃s∈S, x ∈ s), assume s h,
     match s, h with
     ._, ⟨t, hs, rfl⟩ := assume h, this ⟨t, hs, h⟩
     end,
-    assume : ∀s, s ∈ compl '' S → x ∈ s,
+    suppose ∀s, s ∈ compl '' S → x ∈ s,
     assume ⟨t, tS, xt⟩, this (compl t) (mem_image_of_mem _ tS) xt⟩
 
 -- classical
@@ -908,7 +908,7 @@ variable [semilattice_inf_bot α]
 definition disjoint (a b : α) : Prop := a ⊓ b = ⊥
 
 lemma disjoint_symm {a b : α} : disjoint a b → disjoint b a :=
-assume : a ⊓ b = ⊥, show b ⊓ a = ⊥, from this ▸ inf_comm
+suppose a ⊓ b = ⊥, show b ⊓ a = ⊥, from this ▸ inf_comm
 
 lemma disjoint_bot_left {a : α} : disjoint ⊥ a := bot_inf_eq
 lemma disjoint_bot_right {a : α} : disjoint a ⊥ := inf_bot_eq

--- a/data/set/finite.lean
+++ b/data/set/finite.lean
@@ -29,8 +29,8 @@ attribute [simp] finite.empty
 @[simp]
 lemma finite_insert {a : α} {s : set α} (h : finite s) : finite (insert a s) :=
 classical.by_cases
-  (assume : a ∈ s, by simp [*])
-  (assume : a ∉ s, finite.insert a s this h)
+  (suppose a ∈ s, by simp [*])
+  (suppose a ∉ s, finite.insert a s this h)
 
 @[simp]
 lemma finite_singleton {a : α} : finite ({a} : set α) :=

--- a/logic/basic.lean
+++ b/logic/basic.lean
@@ -406,7 +406,7 @@ decidable.not_forall_iff_exists_not p
 theorem forall_or_iff_or_forall {q : Prop} {p : α → Prop} :
   (∀x, q ∨ p x) ↔ q ∨ (∀x, p x) :=
 ⟨assume h, if hq : q then or.inl hq else or.inr $ assume x, or.resolve_left (h x) hq,
-  assume h x, or.imp_right (assume : ∀x, p x, this x) h⟩
+  assume h x, or.imp_right (suppose ∀x, p x, this x) h⟩
 
 end classical
 

--- a/tools/auto/experiments/set_basic.lean
+++ b/tools/auto/experiments/set_basic.lean
@@ -98,7 +98,7 @@ by finish [set_eq_def]
 /- old proof
 theorem exists_mem_of_ne_empty {s : set α} (h : s ≠ ∅) : ∃ x, x ∈ s :=
 classical.by_contradiction
-  (assume : ¬ ∃ x, x ∈ s,
+  (suppose ¬ ∃ x, x ∈ s,
     have ∀ x, x ∉ s, from forall_not_of_not_exists this,
     show false, from h (eq_empty_of_forall_not_mem this))
 -/
@@ -245,7 +245,7 @@ by finish [set_eq_def, iff_def]
 
 /- old proof
 theorem nonempty_of_inter_nonempty_right {T : Type} {s t : set T} (h : s ∩ t ≠ ∅) : t ≠ ∅ :=
-assume : t = ∅,
+suppose t = ∅,
 have s ∩ t = ∅, from eq.subst (eq.symm this) (inter_empty s),
 h this
 -/
@@ -255,7 +255,7 @@ by finish [set_eq_def, iff_def]
 
 /- old proof
 theorem nonempty_of_inter_nonempty_left {T : Type} {s t : set T} (h : s ∩ t ≠ ∅) : s ≠ ∅ :=
-assume : s = ∅,
+suppose s = ∅,
 have s ∩ t = ∅,
   begin rw this, apply empty_inter end,
 h this
@@ -450,8 +450,8 @@ by finish
 /- old proof
 theorem eq_of_mem_singleton {x y : α} (h : x ∈ ({y} : set α)) : x = y :=
 or.elim (eq_or_mem_of_mem_insert h)
-  (assume : x = y, this)
-  (assume : x ∈ (∅ : set α), absurd this (not_mem_empty _))
+  (suppose x = y, this)
+  (suppose x ∈ (∅ : set α), absurd this (not_mem_empty _))
 -/
 
 theorem mem_singleton_of_eq {x y : α} (H : x = y) : x ∈ ({y} : set α) :=
@@ -468,12 +468,12 @@ by finish [set_eq_def]
 /- old proof
 theorem insert_eq (x : α) (s : set α) : insert x s = ({x} : set α) ∪ s :=
 ext (assume y, iff.intro
-  (assume : y ∈ insert x s,
-    or.elim this (assume : y = x, or.inl (or.inl this)) (assume : y ∈ s, or.inr this))
-  (assume : y ∈ ({x} : set α) ∪ s,
+  (suppose y ∈ insert x s,
+    or.elim this (suppose y = x, or.inl (or.inl this)) (suppose y ∈ s, or.inr this))
+  (suppose y ∈ ({x} : set α) ∪ s,
     or.elim this
-      (assume : y ∈ ({x} : set α), or.inl (eq_of_mem_singleton this))
-      (assume : y ∈ s, or.inr this)))
+      (suppose y ∈ ({x} : set α), or.inl (eq_of_mem_singleton this))
+      (suppose y ∈ s, or.inr this)))
 -/
 
 @[simp] theorem insert_of_has_insert (x : α) (a : set α) : has_insert.insert x a = insert x a := rfl
@@ -507,8 +507,8 @@ by finish [set_eq_def, iff_def, subset_def]
 /- old proof
 theorem eq_sep_of_subset {s t : set α} (ssubt : s ⊆ t) : s = {x ∈ t | x ∈ s} :=
 ext (assume x, iff.intro
-  (assume : x ∈ s, ⟨ssubt this, this⟩)
-  (assume : x ∈ {x ∈ t | x ∈ s}, this^.right))
+  (suppose x ∈ s, ⟨ssubt this, this⟩)
+  (suppose x ∈ {x ∈ t | x ∈ s}, this^.right))
 -/
 
 theorem sep_subset (s : set α) (p : α → Prop) : {x ∈ s | p x} ⊆ s :=
@@ -521,7 +521,7 @@ by finish [set_eq_def]
 /- old proof
 theorem forall_not_of_sep_empty {s : set α} {p : α → Prop} (h : {x ∈ s | p x} = ∅) :
   ∀ x ∈ s, ¬ p x :=
-assume x, assume : x ∈ s, assume : p x,
+assume x, suppose x ∈ s, suppose p x,
 have x ∈ {x ∈ s | p x}, from ⟨by assumption, this⟩,
 show false, from ne_empty_of_mem this h
 -/
@@ -791,7 +791,7 @@ theorem mem_image_compl (t : set α) (S : set (set α)) :
 iff.intro
   (assume ⟨t', (Ht' : t' ∈ S), (Ht : -t' = t)⟩,
     show -t ∈ S, begin rw [←Ht, compl_compl], exact Ht' end)
-  (assume : -t ∈ S,
+  (suppose -t ∈ S,
     have -(-t) ∈ compl ' S, from mem_image_of_mem compl this,
     show t ∈ compl ' S, from compl_compl t ▸ this)
 -/
@@ -804,7 +804,7 @@ theorem image_id (s : set α) : id ' s = s :=
 ext (assume x, iff.intro
   (assume ⟨x', (hx' : x' ∈ s), (x'eq : x' = x)⟩,
     show x ∈ s, begin rw [←x'eq], apply hx' end)
-  (assume : x ∈ s, mem_image_of_mem id this))
+  (suppose x ∈ s, mem_image_of_mem id this))
 -/
 
 theorem compl_compl_image (S : set (set α)) :

--- a/topology/topological_space.lean
+++ b/topology/topological_space.lean
@@ -248,7 +248,7 @@ assume a, le_infi $ assume s, le_infi $ assume ⟨h₁, _⟩, principal_mono^.mp
 
 @[simp]
 lemma nhds_neq_bot {a : α} : nhds a ≠ ⊥ :=
-assume : nhds a = ⊥,
+suppose nhds a = ⊥,
 have return a = (⊥ : filter α),
   from lattice.bot_unique $ this ▸ return_le_nhds a,
 return_neq_bot this
@@ -318,7 +318,7 @@ lemma compact_adherence_nhdset {s t : set α} {f : filter α}
   (hs : compact s) (hf₂ : f ≤ principal s) (ht₁ : open' t) (ht₂ : ∀a∈s, nhds a ⊓ f ≠ ⊥ → a ∈ t) :
   t ∈ f.sets :=
 classical.by_cases mem_sets_of_neq_bot $
-  assume : f ⊓ principal (- t) ≠ ⊥,
+  suppose f ⊓ principal (- t) ≠ ⊥,
   let ⟨a, ha, (hfa : f ⊓ principal (-t) ⊓ nhds a ≠ ⊥)⟩ := hs this $ inf_le_left_of_le hf₂ in
   have a ∈ t,
     from ht₂ a ha $ neq_bot_of_le_neq_bot hfa $ le_inf inf_le_right $ inf_le_left_of_le inf_le_left,
@@ -383,7 +383,7 @@ class t2_space (α : Type u) [topological_space α] :=
 (t2 : ∀x y, x ≠ y → ∃u v : set α, open' u ∧ open' v ∧ x ∈ u ∧ y ∈ v ∧ u ∩ v = ∅)
 
 lemma eq_of_nhds_neq_bot [ht : t2_space α] {x y : α} (h : nhds x ⊓ nhds y ≠ ⊥) : x = y :=
-classical.by_contradiction $ assume : x ≠ y,
+classical.by_contradiction $ suppose x ≠ y,
 let ⟨u, v, hu, hv, hx, hy, huv⟩ := t2_space.t2 _ x y this in
 have h₁ : u ∈ (nhds x ⊓ nhds y).sets,
   from @mem_inf_sets_of_left α (nhds x) (nhds y) _ $ mem_nhds_sets hu hx,

--- a/topology/uniform_space.lean
+++ b/topology/uniform_space.lean
@@ -301,7 +301,7 @@ le_antisymm
     have s ⊆ interior d, from
       calc s ⊆ t : hst
        ... ⊆ interior d : (subset_interior_iff_subset_of_open ht).mpr $
-        assume x, assume : x ∈ t, let ⟨x, y, h₁, h₂, h₃⟩ := ht_comp this in hs_comp ⟨x, h₁, y, h₂, h₃⟩,
+        assume x, suppose x ∈ t, let ⟨x, y, h₁, h₂, h₃⟩ := ht_comp this in hs_comp ⟨x, h₁, y, h₂, h₃⟩,
     have interior d ∈ (@uniformity α _).sets,
       from (@uniformity α _).upwards_sets hs $ this,
     by simp [this])
@@ -486,7 +486,7 @@ lemma cauchy_of_totally_bounded_of_ultrafilter {s : set α} {f : filter α}
 
 lemma totally_bounded_iff_filter {s : set α} :
   totally_bounded s ↔ (∀f, f ≠ ⊥ → f ≤ principal s → ∃c ≤ f, cauchy c) :=
-⟨assume : totally_bounded s, assume f hf hs,
+⟨suppose totally_bounded s, assume f hf hs,
   ⟨ultrafilter_of f, ultrafilter_of_le,
     cauchy_of_totally_bounded_of_ultrafilter this
       (ultrafilter_ultrafilter_of hf) (le_trans ultrafilter_of_le hs)⟩,
@@ -1091,8 +1091,8 @@ top_unique $ assume s hs x hx ⟨a₁, a₂⟩ (h₁ : a₁ = a₂) (h₂ : a₁
 
 lemma to_topological_space_bot : @uniform_space.to_topological_space α ⊥ = ⊥ :=
 bot_unique $ assume s hs, classical.by_cases
-  (assume : s = ∅, this.symm ▸ @open_empty _ ⊥)
-  (assume : s ≠ ∅,
+  (suppose s = ∅, this.symm ▸ @open_empty _ ⊥)
+  (suppose s ≠ ∅,
     let ⟨x, hx⟩ := exists_mem_of_ne_empty this in
     have univ ⊆ _,
       from hs x hx,
@@ -1115,7 +1115,7 @@ classical.by_cases
         exact assume a b, rfl
       end
     end)
-  (assume : ¬ nonempty ι,
+  (suppose ¬ nonempty ι,
     le_antisymm
       (have supr u = ⊥, from bot_unique $ supr_le $ assume i, (this ⟨i⟩).elim,
         have @uniform_space.to_topological_space _ (supr u) = ⊥,


### PR DESCRIPTION
When I tried to run the code in rat.lean, I got several errors, all about different usages of `assume :`. It seems that in the past this was equivalent to `suppose`, but is no longer usable. After changing the instances of `assume :` with `suppose` none of the errors from before are there.